### PR TITLE
wik-62: remove rush overlays and fix rush errors

### DIFF
--- a/wikiclue/src/routes/play/+page.svelte
+++ b/wikiclue/src/routes/play/+page.svelte
@@ -27,6 +27,8 @@
     let maxTime: number;
     let maxSkips: number;
     let correctAnswer = false;
+    let skipButtonPressed = false;
+    let autoSkipUsed = false;
     let skipPressedClass = '';
     let correctAnswerClass = "";
 
@@ -60,9 +62,17 @@
             if (timeRemaining > 0) {
                 timeRemaining -= 1;
             } else {
-                gameOver = true;
-                clearInterval(timerInterval);
-                endGame();
+                if (skipsRemaining > 0) {
+                    autoSkipUsed = true;
+                    setTimeout(() => {
+                        autoSkipUsed = false;
+                    }, 2000);
+                    skipPressed();
+                } else {
+                    gameOver = true;
+                    clearInterval(timerInterval);
+                    endGame();
+                }
             }
         }, 1000);
     }
@@ -76,6 +86,11 @@
             }, 2000);
             clearInterval(timerInterval);
             loadNextRound();
+        } else {
+            skipButtonPressed = true;
+            setTimeout(() => {
+                skipButtonPressed = false;
+            }, 2000);
         }
     }
 
@@ -110,29 +125,30 @@
     }
 
     async function loadNextRound() {
-        timeRemaining = maxTime;
-        gameOver = false;
-        searchTerm.set("");
-        const response = await fetch("/api/word-generation");
-        const words = await response.json();
-        wordsToFind[0] = words.word1;
-        wordsToFind[1] = words.word2;
-        let variables = {
-            streakCount: streakCount,
-            timeRemaining: timeRemaining,
-            skipsRemaining: skipsRemaining,
-            maxTime: maxTime,
-            maxSkips: maxSkips,
-            wordsToFind: [words.word1, words.word2],
+        if (!gameOver){
+            timeRemaining = maxTime;
+            searchTerm.set("");
+            const response = await fetch("/api/word-generation");
+            const words = await response.json();
+            wordsToFind[0] = words.word1;
+            wordsToFind[1] = words.word2;
+            let variables = {
+                streakCount: streakCount,
+                timeRemaining: timeRemaining,
+                skipsRemaining: skipsRemaining,
+                maxTime: maxTime,
+                maxSkips: maxSkips,
+                wordsToFind: [words.word1, words.word2],
+            }
+            const headers = new Headers();
+            headers.append("Authorization", token);
+            await fetch('/api/rush-variables', {
+                method: 'POST',
+                headers: headers,
+                body: JSON.stringify({ variables }),
+            });
+            startTimer();
         }
-        const headers = new Headers();
-        headers.append("Authorization", token);
-        await fetch('/api/rush-variables', {
-			method: 'POST',
-            headers: headers,
-			body: JSON.stringify({ variables }),
-		});
-        startTimer();
     }
 
     function endGame() {
@@ -208,10 +224,14 @@
 		<p class="message-container">
             {#if correctAnswer}
                 <span class="correct-answer-message">Correct Answer!</span>
+            {:else if autoSkipUsed}
+                <span class="auto-skip-message">Round automatically skipped!</span>
             {:else if incorrectAnswer}
                 <span class="incorrect-answer">This page does not contain the two words!</span>
             {:else if pageDoesNotExist}
                 <span class="page-not-exist">This page does not exist!</span>
+            {:else if skipButtonPressed && skipsRemaining <= 0}
+                <span class="no-skips">You have no skips remaining!</span>
             {:else}
                 <span class="placeholder">{'\u00A0'}</span>
             {/if}

--- a/wikiclue/src/routes/play/+page.svelte
+++ b/wikiclue/src/routes/play/+page.svelte
@@ -27,7 +27,6 @@
     let maxTime: number;
     let maxSkips: number;
     let correctAnswer = false;
-    let skipUsed = false;
     let skipPressedClass = '';
     let correctAnswerClass = "";
 
@@ -71,10 +70,8 @@
     function skipPressed() {
         if (skipsRemaining > 0) {
             skipsRemaining--;
-            skipUsed = true;
             skipPressedClass = 'skip-pressed';
             setTimeout(() => {
-                skipUsed = false;
                 skipPressedClass = '';
             }, 2000);
             clearInterval(timerInterval);
@@ -183,21 +180,21 @@
             <RushIcon style="font-size: 2rem; color: black;"/>
             <p class="info-text">
                 <span class="streak-text">Current Streak:</span>
-                <span class="streak-content">{streakCount !== undefined ? streakCount : 0}</span>
+                <span class="streak-content">{streakCount !== undefined ? streakCount : ""}</span>
             </p>
         </div>
         <div class="info-container">
             <TimerIcon style="font-size: 2rem; color: black;"/>
             <p class="info-text">
                 <span class="time-text">Time Remaining:</span>
-                <span class="time-content">{timeRemaining !== undefined ? timeRemaining : "00"}</span>
+                <span class="time-content">{timeRemaining !== undefined ? timeRemaining : ""}</span>
             </p>
         </div>
         <div class="info-container {skipPressedClass}">
             <SkipIcon style="font-size: 2rem; color: black;"/>
             <p class="info-text">
                 <span class="skips-text">Skips Remaining:</span>
-                <span class="skips-content">{skipsRemaining !== undefined ? skipsRemaining : 0}</span>
+                <span class="skips-content">{skipsRemaining !== undefined ? skipsRemaining : ""}</span>
             </p>
         </div>
     </div>

--- a/wikiclue/src/routes/rush/+page.svelte
+++ b/wikiclue/src/routes/rush/+page.svelte
@@ -4,8 +4,6 @@
     import RushIcon from '~icons/nimbus/fire'
     import TimerIcon from '~icons/material-symbols/timer-outline'
     import SkipIcon from '~icons/bi/skip-forward'
-    import Overlay from "../../components/overlay.svelte";
-	import { writable } from "svelte/store";
     import { onMount } from "svelte";
     import { searchTerm } from "../../store/gameplay";
 	import { authHandlers } from "../../store/store";
@@ -16,7 +14,6 @@
 	import { browser } from "$app/environment";
 	import { auth } from "../../firebase/firebase";
 
-    const isOverlayOpen = writable(false);
     let wordsToFind = ["", ""];
     let skipsRemaining: number;
     let timeRemaining: number;
@@ -25,8 +22,6 @@
     let incorrectAnswer = false;
     let gameOver = false;
     let timerInterval: NodeJS.Timeout;
-    let correctOverlay = false;
-    let skippedOverlay = false;
     let endOverlay = false;
     let timeAllowed: number;
     let token: string;
@@ -34,6 +29,10 @@
     let maxSkips: number;
     let userData: any;
     let rushMaxStreak: number;
+    let correctAnswer = false;
+    let skipUsed = false;
+    let skipPressedClass = '';
+    let correctAnswerClass = "";
 
     onMount(async () => {
         await auth.onAuthStateChanged(async (user) => {
@@ -46,7 +45,6 @@
         }
         loadGameplayVariables();
         startTimer();
-        window.addEventListener('beforeunload', handleBeforeUnload); 
     });
 
     async function loadGameplayVariables() {
@@ -63,13 +61,6 @@
         maxSkips = data.maxSkips;
     }
 
-    function handleBeforeUnload(event: BeforeUnloadEvent) {
-        if($isOverlayOpen) {
-            timeRemaining = maxTime;
-            loadNextRound();
-        }
-    }
-
     function startTimer() {
         clearInterval(timerInterval);
         timerInterval = setInterval(() => {
@@ -84,18 +75,22 @@
     }
 
     function skipPressed() {
-        if (skipsRemaining > 0 && !$isOverlayOpen) {
+        if (skipsRemaining > 0) {
             skipsRemaining--;
+            skipUsed = true;
+            skipPressedClass = 'skip-pressed';
+            setTimeout(() => {
+                skipUsed = false;
+                skipPressedClass = '';
+            }, 2000);
             clearInterval(timerInterval);
-            isOverlayOpen.set(true);
-            skippedOverlay = true;
+            loadNextRound();
         }
     }
 
     async function rushConfirmFunction() {
         incorrectAnswer = false;
         let pageContent = await getWikiPageContent($searchTerm);
-
 		if (!pageContent){
 			pageDoesNotExist = true;
 			setTimeout(() => {
@@ -103,17 +98,18 @@
 			}, 2000);
 			return;
 		}
-
-        // Found a correct answer
 		if (pageContent.includes(wordsToFind[0].toLowerCase()) && pageContent.includes(wordsToFind[1].toLowerCase())) {
+            correctAnswer = true;
+            correctAnswerClass = "correct-answer";
+            setTimeout(() => {
+                correctAnswer = false;
+                correctAnswerClass = "";
+            }, 2000);
             await authHandlers.updateRushWins(wordsToFind, timeAllowed - timeRemaining, $searchTerm);
             clearInterval(timerInterval);
             streakCount++;
-            isOverlayOpen.set(true);
-            correctOverlay = true;
+            await loadNextRound();
         }
-
-        // Did not find a correct answer
         else {
             incorrectAnswer = true;
             setTimeout(() => {
@@ -149,18 +145,15 @@
     }
 
     async function endGame() {
-        if (!$isOverlayOpen) {
-            gameOver = true;
-            sessionStorage.clear();
-            clearInterval(timerInterval);
-            rushMaxStreak = await authHandlers.getUserRushData(userData.uid);
-            if (streakCount > rushMaxStreak) {
-                await authHandlers.updateUserRushData(userData.uid, streakCount);
-                rushMaxStreak = streakCount;
-            }
-            isOverlayOpen.set(true);
-            endOverlay = true;
+        gameOver = true;
+        sessionStorage.clear();
+        clearInterval(timerInterval);
+        rushMaxStreak = await authHandlers.getUserRushData(userData.uid);
+        if (streakCount > rushMaxStreak) {
+            await authHandlers.updateUserRushData(userData.uid, streakCount);
+            rushMaxStreak = streakCount;
         }
+        endOverlay = true;
     }
 
     async function startNewGame() {
@@ -191,28 +184,13 @@
             window.location.reload();
         }
     }
-
-    async function onEnterPressed(event: KeyboardEvent) {
-        if (event.key === "Enter" && $isOverlayOpen) {
-            if(gameOver){
-                return;
-            }
-            if(correctOverlay){
-                loadNextRound();
-                isOverlayOpen.set(false);
-                return;
-            }
-        }
-    }
 </script>
-
-<svelte:window on:keydown={onEnterPressed}/>
 
 <HeaderBar />
 <div class="rush-page">
     <GameHeader header="Rush" arrow={true} backLink="/home"/>
     <div class="info-bar">
-        <div class="info-container">
+        <div class="info-container {correctAnswerClass}">
             <RushIcon style="font-size: 2rem; color: black;"/>
             <p class="info-text">
                 <span class="streak-text">Current Streak:</span>
@@ -226,7 +204,7 @@
                 <span class="time-content">{timeRemaining !== undefined ? timeRemaining : "00"}</span>
             </p>
         </div>
-        <div class="info-container">
+        <div class="info-container {skipPressedClass}">
             <SkipIcon style="font-size: 2rem; color: black;"/>
             <p class="info-text">
                 <span class="skips-text">Skips Remaining:</span>
@@ -241,38 +219,20 @@
             <p class="search-words">{wordsToFind[0]}</p>
             <p class="search-words">{wordsToFind[1]}</p>
         </div>
-		<p class="incorrect-answer">
-			{incorrectAnswer ? 'This page does not contain the two words' : '\u00A0'}
-			{pageDoesNotExist ? 'This page does not exist' : '\u00A0'}
-		</p>
+		<p class="message-container">
+            {#if correctAnswer}
+                <span class="correct-answer-message">Correct Answer!</span>
+            {:else if incorrectAnswer}
+                <span class="incorrect-answer">This page does not contain the two words!</span>
+            {:else if pageDoesNotExist}
+                <span class="page-not-exist">This page does not exist!</span>
+            {:else}
+                <span class="placeholder">{'\u00A0'}</span>
+            {/if}
+        </p>
 		<SearchComponent gameOver={gameOver} confirmFunction={rushConfirmFunction} />
 	</div>
-    {#if $isOverlayOpen && correctOverlay}
-        <Overlay header="Correct!" onClose={() => {loadNextRound(); isOverlayOpen.set(false); correctOverlay = false}}>
-            <div class="popup-info-container">
-                <p class="popup-description">You found a page that contains the two words! Keep it up!</p>
-                <div class="streak-container">
-                    <RushIcon style="font-size: 3.5rem;"/>
-                    <p class="popup-text">Current Streak: {streakCount}</p>
-                </div>
-            </div>
-            <button class="popup-button" on:click={() => {loadNextRound(); isOverlayOpen.set(false); correctOverlay = false}}>Next Round</button>
-        </Overlay>
-    {/if}
-    {#if $isOverlayOpen && skippedOverlay}
-        <Overlay header="Skipped!" onClose={() => {loadNextRound(); isOverlayOpen.set(false); skippedOverlay = false}}>
-            <div class="popup-info-container">
-                <p class="popup-description">You have skipped this round!</p>
-                <div class="streak-container">
-                    <SkipIcon style="font-size: 3.5rem; color: black;"/>
-                    <p class="popup-text">Skips Remaining: {skipsRemaining}</p>
-                </div>
-            </div>
-            
-            <button class="popup-button" on:click={() => {loadNextRound(); isOverlayOpen.set(false); skippedOverlay = false}}>Next Round</button>
-        </Overlay>
-    {/if}
-    {#if $isOverlayOpen && endOverlay}
+    {#if endOverlay}
         <RushEnd
         playAgain={()=>{startNewGame()}} returnToMenu={()=>{goto("/home")}} streak={streakCount} maxStreak={rushMaxStreak}/>
     {/if}

--- a/wikiclue/src/routes/rush/+page.svelte
+++ b/wikiclue/src/routes/rush/+page.svelte
@@ -30,7 +30,6 @@
     let userData: any;
     let rushMaxStreak: number;
     let correctAnswer = false;
-    let skipUsed = false;
     let skipPressedClass = '';
     let correctAnswerClass = "";
 
@@ -77,10 +76,8 @@
     function skipPressed() {
         if (skipsRemaining > 0) {
             skipsRemaining--;
-            skipUsed = true;
             skipPressedClass = 'skip-pressed';
             setTimeout(() => {
-                skipUsed = false;
                 skipPressedClass = '';
             }, 2000);
             clearInterval(timerInterval);
@@ -194,21 +191,21 @@
             <RushIcon style="font-size: 2rem; color: black;"/>
             <p class="info-text">
                 <span class="streak-text">Current Streak:</span>
-                <span class="streak-content">{streakCount !== undefined ? streakCount : 0}</span>
+                <span class="streak-content">{streakCount !== undefined ? streakCount : ""}</span>
             </p>
         </div>
         <div class="info-container">
             <TimerIcon style="font-size: 2rem; color: black;"/>
             <p class="info-text">
                 <span class="time-text">Time Remaining:</span>
-                <span class="time-content">{timeRemaining !== undefined ? timeRemaining : "00"}</span>
+                <span class="time-content">{timeRemaining !== undefined ? timeRemaining : ""}</span>
             </p>
         </div>
         <div class="info-container {skipPressedClass}">
             <SkipIcon style="font-size: 2rem; color: black;"/>
             <p class="info-text">
                 <span class="skips-text">Skips Remaining:</span>
-                <span class="skips-content">{skipsRemaining !== undefined ? skipsRemaining : 0}</span>
+                <span class="skips-content">{skipsRemaining !== undefined ? skipsRemaining : ""}</span>
             </p>
         </div>
     </div>

--- a/wikiclue/src/styles/rushPageStyles.css
+++ b/wikiclue/src/styles/rushPageStyles.css
@@ -79,11 +79,19 @@
 	color: var(--success-color);
 }
 
+.auto-skip-message {
+	color: var(--skip);
+}
+
 .incorrect-answer {
 	color: var(--error-color);
 }
 
 .page-not-exist {
+	color: var(--error-color);
+}
+
+.no-skips {
 	color: var(--error-color);
 }
 

--- a/wikiclue/src/styles/rushPageStyles.css
+++ b/wikiclue/src/styles/rushPageStyles.css
@@ -70,10 +70,21 @@
 	margin: 0;
 }
 
-.incorrect-answer {
+.message-container {
 	font-size: 1.1rem;
-	color: var(--error-color);
 	margin: 0;
+}
+
+.correct-answer-message {
+	color: var(--success-color);
+}
+
+.incorrect-answer {
+	color: var(--error-color);
+}
+
+.page-not-exist {
+	color: var(--error-color);
 }
 
 .skip-button {
@@ -139,4 +150,32 @@
 
 .popup-button:hover {
 	background-color: var(--default-button-color-lighter);
+}
+
+.skip-pressed {
+	background-color: var(--skip);
+	animation: skippedFadeOut 2s forwards;
+}
+
+.correct-answer {
+	background-color: var(--success-color);
+	animation: correctFadeOut 2s forwards;
+}
+
+@keyframes correctFadeOut {
+	from {
+		background-color: var(--success-color);
+	}
+	to {
+		background-color: transparent;
+	}
+}
+
+@keyframes skippedFadeOut {
+	from {
+		background-color: var(--skip);
+	}
+	to {
+		background-color: transparent;
+	}
 }


### PR DESCRIPTION
After a discussion with Colin we decided to remove the rush overlays to improve the user experience and solve a bunch of refresh/async issues that were happening and make it feel like a more genuine "rush" style of game where the user cannot take a break.

Let me know what you think of the colors when a user presses skip or gets an answer correct. 