### PR TITLE
Flesh out levels menu and functionality

### DIFF
--- a/wikiclue/src/components/searchComponent.svelte
+++ b/wikiclue/src/components/searchComponent.svelte
@@ -81,6 +81,7 @@
 		bind:value={$searchTerm}
 		on:input={() => onKeyPress()}
 		on:keydown={(event) => handleKeyDown(event)}
+		disabled={gameOver}
   />
   <button class="confirm-answer" disabled={gameOver} on:click={() => confirmFunction()}>Search</button>
 </div>
@@ -92,6 +93,7 @@
 		<button
 			class="search-result {index === selectedResult ? 'selected' : ''}"
 			on:click={() => onSelectPage(option)}
+			disabled={gameOver}
 		>
 			{option}
 		</button>

--- a/wikiclue/src/global.css
+++ b/wikiclue/src/global.css
@@ -17,6 +17,7 @@
 	--friend-border: #ccc;
 	--card-background: #f8f9fa;
 	--card-background-darker: #f8f9fa75;
+	--card-background-locked: #8b8b8b75;
 	--error-color: red;
 	--success-color: green;
 

--- a/wikiclue/src/routes/home/+page.svelte
+++ b/wikiclue/src/routes/home/+page.svelte
@@ -9,30 +9,14 @@
     import { goto } from '$app/navigation';
 	import { writable } from "svelte/store";
     import { browser } from '$app/environment';
-	import { auth } from "../../firebase/firebase";
-	import { onMount } from "svelte";
     import { authHandlers } from "../../store/store";
 
     let levelsOpen = false;
     let dailyOpen = false;
     let rushOpen = false;
-    let levelsSelectorOpen = false;
     const isOverlayOpen = writable(false);
-    let userLevelsData: any;
-    let difficultySelected = "easy";
     let timeRemaining: number;
     let skipsRemaining: number;
-
-    onMount (async () => {
-        await auth.onAuthStateChanged(async (user) => {
-            const userData = user;
-            if(userData){
-                userLevelsData = await authHandlers.getUserCurrentLevelsData(userData.uid);
-            }
-            // Would need to use this functionality to pre load levels data with words from database
-            // depending on if the user selects easy medium or hard
-        });
-    });
 
     async function playRush() {
         if (browser) {
@@ -92,51 +76,20 @@
             <button class="play-button" on:click={() => {isOverlayOpen.set(true); rushOpen = true;}}>Play Rush</button>
         </div>
     </div>
-    
+
     {#if $isOverlayOpen && levelsOpen}
         <Overlay header="Levels" onClose={() => {isOverlayOpen.set(false); levelsOpen = false;}}>
             <p class="popup-description">In this game mode you will have unlimited time to try and complete 30 levels of increasing difficulty! Are you ready for the challenge?</p>
             <LevelsIcon style="font-size: 5.0rem; color: black; margin: 5%"/>
-            <button class="popup-button" on:click={() => {levelsOpen = false; levelsSelectorOpen = true;}}>Select Difficulty</button>
-        </Overlay>   
-    {/if}
-    {#if $isOverlayOpen && levelsSelectorOpen}
-        <Overlay header="Select Difficulty" onClose={() => {isOverlayOpen.set(false); levelsSelectorOpen = false;}}>
-            <div class="difficulty-selector">
-                <div>
-                    <input id="easy" name="difficulty" value="easy" type="radio" bind:group={difficultySelected}/>
-                    <label for="easy">Easy</label>
-                </div>
-                <div>
-                    <input id="medium" name="difficulty" value="medium" type="radio" bind:group={difficultySelected}/>
-                    <label for="medium">Medium</label>
-                </div>
-                <div>
-                    <input  id="hard" name="difficulty" value="hard" type="radio" bind:group={difficultySelected}/>
-                    <label for="hard" class="disabled">Hard</label>
-                </div>
-            </div>
-            <p class="popup-description">
-                {#if difficultySelected === 'easy'}
-                    You are currently on level {userLevelsData[0]} in Easy!
-                {:else if difficultySelected === 'medium'}
-                    You are currently on level {userLevelsData[1]} in Medium!
-                {:else if difficultySelected === 'hard'}
-                    You are currently on level {userLevelsData[2]} in Hard!
-                {:else}
-                    Please select a difficulty!
-                {/if}
-            </p>
-            <LevelsIcon style="font-size: 5.0rem; color: black; margin: 7.5%"/>
-            <button class="popup-button" on:click={() => goto(`/levels/${difficultySelected}`)}>Play Now!</button>
-        </Overlay>   
+            <button class="popup-button" on:click={()=>goto("/levels")}>Play Now!</button>
+        </Overlay>
     {/if}
     {#if $isOverlayOpen && dailyOpen}
         <Overlay header="The Daily" onClose={() => {isOverlayOpen.set(false); dailyOpen = false;}}>
             <p class="popup-description">Solve the daily problem as fast as possible! Come back everyday to build your streak!</p>
             <DailyIcon style="font-size: 6rem; color: black; margin: 10%"/>
             <button class="popup-button" on:click={()=>goto("/daily")}>Play Now!</button>
-        </Overlay>   
+        </Overlay>
     {/if}
     {#if $isOverlayOpen && rushOpen}
         <Overlay header="Rush" onClose={() => {isOverlayOpen.set(false); rushOpen = false;}}>
@@ -159,7 +112,7 @@
                 <p class="popup-text">You have up to 3 minutes per round</p>
             </div>
             <button class="popup-button" on:click={() => playRush()}>Play Now!</button>
-        </Overlay>   
+        </Overlay>
     {/if}
 </div>
 

--- a/wikiclue/src/routes/levels/+page.svelte
+++ b/wikiclue/src/routes/levels/+page.svelte
@@ -1,21 +1,48 @@
 <script lang="ts">
   import HeaderBar from "../../components/headerBar.svelte";
   import GameHeader from "../../components/gameHeader.svelte";
+  import LockIcon from '~icons/carbon/locked';
   import { goto } from '$app/navigation';
   import { writable } from "svelte/store";
+  import { auth } from "../../firebase/firebase";
   import { authHandlers } from "../../store/store";
   import { onMount } from "svelte";
 
   let selectedDifficulty = 'easy';
   let levelData: any[];
+  let userData: any;
+  let userLevelsData: any;
+  let maxLevel: number;
 
   onMount (async () => {
-      levelData = await authHandlers.getLevels('easy');
+    await new Promise<void>((resolve) => {
+        auth.onAuthStateChanged(async (user: any) => {
+            userData = user;
+            if(userData){
+                userLevelsData = await authHandlers.getUserCurrentLevelsData(userData.uid);
+            }
+            resolve();
+        });
+    });
+
+    // Default to easy
+    maxLevel = userLevelsData[0];
+    levelData = await authHandlers.getLevels('easy');
   });
 
   async function handleOptionChange(event: { target: any; }) {
       selectedDifficulty = event.target.value;
       levelData = await authHandlers.getLevels(selectedDifficulty);
+      if (selectedDifficulty === "easy"){
+          maxLevel = userLevelsData[0];
+      }
+      else if (selectedDifficulty === "medium"){
+          maxLevel = userLevelsData[1];
+      }
+      else if (selectedDifficulty === "hard"){
+          maxLevel = userLevelsData[2];
+      }
+      console.log(maxLevel);
   }
 
   function handleLevelClick(level: number) {
@@ -44,9 +71,15 @@
   <div class="level-options-container">
       {#if levelData}
           {#each Object.keys(levelData) as level, index}
-              <button class="level" on:click={() => handleLevelClick(index)}>
-                {index + 1}
-              </button>
+              {#if index < maxLevel}
+                  <button class="level" on:click={() => handleLevelClick(index)}>
+                    {index+1}
+                  </button>
+              {:else}
+                  <button class="level" disabled={true}>
+                    <LockIcon style="font-size: 1.5rem; color: black" />
+                  </button>
+              {/if}
           {/each}
       {:else}
           <p>Loading...</p>

--- a/wikiclue/src/routes/levels/+page.svelte
+++ b/wikiclue/src/routes/levels/+page.svelte
@@ -1,18 +1,14 @@
 <script lang="ts">
   import HeaderBar from "../../components/headerBar.svelte";
   import GameHeader from "../../components/gameHeader.svelte";
+  import { levelNumber } from "../../store/gameplay";
   import { goto } from '$app/navigation';
   import { writable } from "svelte/store";
   import { authHandlers } from "../../store/store";
   import { onMount } from "svelte";
 
-  const isAddOverlayOpen = writable(false);
-  const isEditOverlayOpen = writable(false);
   let selectedDifficulty = 'easy';
-  let selectedLevel: number;
   let levelData: any[];
-  let wordOne = '';
-  let wordTwo = '';
 
   onMount (async () => {
       levelData = await authHandlers.getLevels('easy');
@@ -23,32 +19,10 @@
       levelData = await authHandlers.getLevels(selectedDifficulty);
   }
 
-  function handleAddLevel() {
-      wordOne = '';
-      wordTwo = '';
-      isAddOverlayOpen.set(true);
-  }
-
-  async function handleCreateLevel() {
-      await authHandlers.updateLevel(selectedDifficulty, levelData.length, {wordOne, wordTwo});
-      isAddOverlayOpen.set(false);
-      levelData = await authHandlers.getLevels(selectedDifficulty);
-  }
-
-  async function handleChangeLevel() {
-      await authHandlers.updateLevel(selectedDifficulty, selectedLevel - 1, {wordOne, wordTwo});
-      isEditOverlayOpen.set(false);
-      levelData = await authHandlers.getLevels(selectedDifficulty);
-  }
-
-  function viewLevel(level: number) {
-      wordOne = '';
-      wordTwo = '';
-      selectedLevel = level;
-      isEditOverlayOpen.set(true);
-      const levelWords = levelData[level - 1];
-      wordOne = levelWords.wordOne;
-      wordTwo = levelWords.wordTwo;
+  function handleLevelClick(level: number) {
+      console.log("clicked level " + level);
+      levelNumber.set(level);
+      goto(`/levels/${selectedDifficulty}`);
   }
 
 </script>
@@ -56,36 +30,31 @@
 
 <HeaderBar />
 <div class="select-level-page">
-  <GameHeader header="Pick a level to play" arrow={true} backLink="/home"/>
+  <GameHeader header="Pick a level" arrow={true} backLink="/home"/>
 
-  <div class="options-container">
-
-      <div class="change-difficulty">
-          <h3>Difficulty:</h3>
-          <div class="select">
-              <select class="dropdown" on:change={handleOptionChange}>
-                  <option value="easy">Easy</option>
-                  <option value="medium">Medium</option>
-                  <option value="hard">Hard</option>
-              </select>
-              <span class="focus"></span>
-          </div>
-      </div>
-  </div>
+    <div class="change-difficulty">
+        <h3>Difficulty:</h3>
+        <div class="select">
+            <select class="dropdown" on:change={handleOptionChange}>
+                <option value="easy">Easy</option>
+                <option value="medium">Medium</option>
+                <option value="hard">Hard</option>
+            </select>
+            <span class="focus"></span>
+        </div>
+    </div>
 
   <div class="level-options-container">
       {#if levelData}
           {#each Object.keys(levelData) as level, index}
-              <!-- svelte-ignore a11y-click-events-have-key-events -->
-              <div class="level" role="button" tabindex={index} on:click={() => viewLevel(index + 1)}>
-                  {index + 1}
-              </div>
+              <button class="level" on:click={() => handleLevelClick(index)}>
+                {index + 1}
+              </button>
           {/each}
       {:else}
           <p>Loading...</p>
       {/if}
   </div>
-  <button class="popup-button" on:click={() => goto(`/levels/${selectedDifficulty}`)}>GOOO!</button>
 </div>
 
 <style>

--- a/wikiclue/src/routes/levels/+page.svelte
+++ b/wikiclue/src/routes/levels/+page.svelte
@@ -1,92 +1,91 @@
 <script lang="ts">
-  import HeaderBar from "../../components/headerBar.svelte";
-  import GameHeader from "../../components/gameHeader.svelte";
-  import LockIcon from '~icons/carbon/locked';
-  import { goto } from '$app/navigation';
-  import { writable } from "svelte/store";
-  import { auth } from "../../firebase/firebase";
-  import { authHandlers } from "../../store/store";
-  import { onMount } from "svelte";
+    import HeaderBar from "../../components/headerBar.svelte";
+    import GameHeader from "../../components/gameHeader.svelte";
+    import LockIcon from '~icons/carbon/locked';
+    import { goto } from '$app/navigation';
+    import { writable } from "svelte/store";
+    import { auth } from "../../firebase/firebase";
+    import { authHandlers } from "../../store/store";
+    import { onMount } from "svelte";
 
-  let selectedDifficulty = 'easy';
-  let levelData: any[];
-  let userData: any;
-  let userLevelsData: any;
-  let maxLevel: number;
+    let selectedDifficulty = 'easy';
+    let difficultyInt = 0;
+    let levelData: any[] = [undefined, undefined, undefined];
+    let userData: any;
+    let userLevelsData: any;
 
-  onMount (async () => {
-    await new Promise<void>((resolve) => {
-        auth.onAuthStateChanged(async (user: any) => {
-            userData = user;
-            if(userData){
-                userLevelsData = await authHandlers.getUserCurrentLevelsData(userData.uid);
-            }
-            resolve();
+    onMount (async () => {
+        await new Promise<void>((resolve) => {
+            auth.onAuthStateChanged(async (user: any) => {
+                userData = user;
+                if(userData){
+                    userLevelsData = await authHandlers.getUserCurrentLevelsData(userData.uid);
+                }
+                resolve();
+            });
         });
+
+        // Load all level data
+        levelData[0] = await authHandlers.getLevels('easy');
+        levelData[1] = await authHandlers.getLevels('medium');
+        levelData[2] = await authHandlers.getLevels('hard');
     });
 
-    // Default to easy
-    maxLevel = userLevelsData[0];
-    levelData = await authHandlers.getLevels('easy');
-  });
+    async function handleOptionChange(event: { target: any; }) {
+        selectedDifficulty = event.target.value;
+        if (selectedDifficulty === "easy"){
+            difficultyInt = 0;
+        }
+        else if (selectedDifficulty === "medium"){
+            difficultyInt = 1;
+        }
+        else if (selectedDifficulty === "hard"){
+            difficultyInt = 2;
+        }
+    }
 
-  async function handleOptionChange(event: { target: any; }) {
-      selectedDifficulty = event.target.value;
-      levelData = await authHandlers.getLevels(selectedDifficulty);
-      if (selectedDifficulty === "easy"){
-          maxLevel = userLevelsData[0];
-      }
-      else if (selectedDifficulty === "medium"){
-          maxLevel = userLevelsData[1];
-      }
-      else if (selectedDifficulty === "hard"){
-          maxLevel = userLevelsData[2];
-      }
-      console.log(maxLevel);
-  }
-
-  function handleLevelClick(level: number) {
-      goto(`/levels/${selectedDifficulty}-${level+1}`);
-  }
+    function handleLevelClick(level: number) {
+        goto(`/levels/${selectedDifficulty}-${level+1}`);
+    }
 
 </script>
 
 
 <HeaderBar />
 <div class="select-level-page">
-  <GameHeader header="Pick a level" arrow={true} backLink="/home"/>
+    <GameHeader header="Pick a level" arrow={true} backLink="/home"/>
 
-    <div class="change-difficulty">
-        <h3>Difficulty:</h3>
-        <div class="select">
-            <select class="dropdown" on:change={handleOptionChange}>
-                <option value="easy">Easy</option>
-                <option value="medium">Medium</option>
-                <option value="hard">Hard</option>
-            </select>
-            <span class="focus"></span>
+        <div class="change-difficulty">
+            <h3>Difficulty:</h3>
+            <div class="select">
+                <select class="dropdown" on:change={handleOptionChange}>
+                    <option value="easy">Easy</option>
+                    <option value="medium">Medium</option>
+                    <option value="hard">Hard</option>
+                </select>
+                <span class="focus"></span>
+            </div>
         </div>
-    </div>
 
-  <div class="level-options-container">
-      {#if levelData}
-          {#each Object.keys(levelData) as level, index}
-              {#if index <= maxLevel}
-                  <button class="level" on:click={() => handleLevelClick(index)}>
-                    {index+1}
-                  </button>
-              {:else}
-                  <button class="level" disabled={true}>
-                    <LockIcon style="font-size: 1.5rem; color: black" />
-                  </button>
-              {/if}
-          {/each}
-      {:else}
-          <p>Loading...</p>
-      {/if}
-  </div>
+    <div class="level-options-container">
+        {#if levelData[difficultyInt]}
+            {#each Object.keys(levelData[difficultyInt]) as level, index}
+                {#if index <= userLevelsData[difficultyInt]}
+                    <button class="level" on:click={() => handleLevelClick(index)}>
+                        {index+1}
+                    </button>
+                {:else}
+                    <button class="level" disabled={true}>
+                        <LockIcon style="font-size: 1.5rem; color: black" />
+                    </button>
+                {/if}
+            {/each}
+        {:else}
+            <p>Loading...</p>
+        {/if}
+    </div>
 </div>
 
 <style>
-  @import '../../styles/selectLevelPageStyles.css';
+    @import '../../styles/selectLevelPageStyles.css';
 </style>

--- a/wikiclue/src/routes/levels/+page.svelte
+++ b/wikiclue/src/routes/levels/+page.svelte
@@ -1,4 +1,91 @@
-<h1>Plain /levels route</h1>
-<p>If you got here from a button click, it is a bug, pls report</p>
-<p>If you navigated here manually, this page is not completed. Eventually harry wants to make it a menu</p>
-<p>Go to levels/easy, levels/medium, or levels/hard to actually play</p>
+<script lang="ts">
+  import HeaderBar from "../../components/headerBar.svelte";
+  import GameHeader from "../../components/gameHeader.svelte";
+  import { writable } from "svelte/store";
+  import { authHandlers } from "../../store/store";
+  import { onMount } from "svelte";
+
+  const isAddOverlayOpen = writable(false);
+  const isEditOverlayOpen = writable(false);
+  let selectedDifficulty = 'easy';
+  let selectedLevel: number;
+  let levelData: any[];
+  let wordOne = '';
+  let wordTwo = '';
+
+  onMount (async () => {
+      levelData = await authHandlers.getLevels('easy');
+  });
+
+  async function handleOptionChange(event: { target: any; }) {
+      selectedDifficulty = event.target.value;
+      levelData = await authHandlers.getLevels(selectedDifficulty);
+  }
+
+  function handleAddLevel() {
+      wordOne = '';
+      wordTwo = '';
+      isAddOverlayOpen.set(true);
+  }
+
+  async function handleCreateLevel() {
+      await authHandlers.updateLevel(selectedDifficulty, levelData.length, {wordOne, wordTwo});
+      isAddOverlayOpen.set(false);
+      levelData = await authHandlers.getLevels(selectedDifficulty);
+  }
+
+  async function handleChangeLevel() {
+      await authHandlers.updateLevel(selectedDifficulty, selectedLevel - 1, {wordOne, wordTwo});
+      isEditOverlayOpen.set(false);
+      levelData = await authHandlers.getLevels(selectedDifficulty);
+  }
+
+  function viewLevel(level: number) {
+      wordOne = '';
+      wordTwo = '';
+      selectedLevel = level;
+      isEditOverlayOpen.set(true);
+      const levelWords = levelData[level - 1];
+      wordOne = levelWords.wordOne;
+      wordTwo = levelWords.wordTwo;
+  }
+
+</script>
+
+
+<HeaderBar />
+<div class="select-level-page">
+  <GameHeader header="Pick a level to play" arrow={true} backLink="/home"/>
+
+  <div class="options-container">
+
+      <div class="change-difficulty">
+          <h3>Difficulty:</h3>
+          <div class="select">
+              <select class="dropdown" on:change={handleOptionChange}>
+                  <option value="easy">Easy</option>
+                  <option value="medium">Medium</option>
+                  <option value="hard">Hard</option>
+              </select>
+              <span class="focus"></span>
+          </div>
+      </div>
+  </div>
+
+  <div class="level-options-container">
+      {#if levelData}
+          {#each Object.keys(levelData) as level, index}
+              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <div class="level" role="button" tabindex={index} on:click={() => viewLevel(index + 1)}>
+                  {index + 1}
+              </div>
+          {/each}
+      {:else}
+          <p>Loading...</p>
+      {/if}
+  </div>
+</div>
+
+<style>
+  @import '../../styles/selectLevelPageStyles.css';
+</style>

--- a/wikiclue/src/routes/levels/+page.svelte
+++ b/wikiclue/src/routes/levels/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import HeaderBar from "../../components/headerBar.svelte";
   import GameHeader from "../../components/gameHeader.svelte";
-  import { levelNumber } from "../../store/gameplay";
   import { goto } from '$app/navigation';
   import { writable } from "svelte/store";
   import { authHandlers } from "../../store/store";
@@ -20,9 +19,7 @@
   }
 
   function handleLevelClick(level: number) {
-      console.log("clicked level " + level);
-      levelNumber.set(level);
-      goto(`/levels/${selectedDifficulty}`);
+      goto(`/levels/${selectedDifficulty}-${level+1}`);
   }
 
 </script>

--- a/wikiclue/src/routes/levels/+page.svelte
+++ b/wikiclue/src/routes/levels/+page.svelte
@@ -71,7 +71,7 @@
   <div class="level-options-container">
       {#if levelData}
           {#each Object.keys(levelData) as level, index}
-              {#if index < maxLevel}
+              {#if index <= maxLevel}
                   <button class="level" on:click={() => handleLevelClick(index)}>
                     {index+1}
                   </button>

--- a/wikiclue/src/routes/levels/+page.svelte
+++ b/wikiclue/src/routes/levels/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import HeaderBar from "../../components/headerBar.svelte";
   import GameHeader from "../../components/gameHeader.svelte";
+  import { goto } from '$app/navigation';
   import { writable } from "svelte/store";
   import { authHandlers } from "../../store/store";
   import { onMount } from "svelte";
@@ -84,6 +85,7 @@
           <p>Loading...</p>
       {/if}
   </div>
+  <button class="popup-button" on:click={() => goto(`/levels/${selectedDifficulty}`)}>GOOO!</button>
 </div>
 
 <style>

--- a/wikiclue/src/routes/levels/[difficulty]/+page.svelte
+++ b/wikiclue/src/routes/levels/[difficulty]/+page.svelte
@@ -4,7 +4,7 @@
     import Overlay from "../../../components/overlay.svelte";
 	import { writable } from "svelte/store";
     import { onMount } from "svelte";
-    import { searchTerm, searchResults } from '../../../store/gameplay';
+    import { searchTerm, searchResults, levelNumber } from '../../../store/gameplay';
     import { goto } from '$app/navigation';
     import { page } from '$app/stores';
     import { authHandlers } from "../../../store/store";
@@ -32,31 +32,34 @@
     async function setupLevel(){
         searchTerm.set('');
         searchResults.set([]);
-        await new Promise<void>((resolve) => {
-        auth.onAuthStateChanged(async (user) => {
-            userData = user;
-            if(userData){
-                userLevelsData = await authHandlers.getUserCurrentLevelsData(userData.uid);
-                if (userLevelsData && difficulty === "easy"){
-                    currentUserLevel = userLevelsData[0];
-                }
-                else if (userLevelsData && difficulty === "medium"){
-                    currentUserLevel = userLevelsData[1];
-                }
-                else if (userLevelsData && difficulty === "hard"){
-                    currentUserLevel = userLevelsData[2];
-                }
-            }
-            resolve();
-        });
-    });
+        // await new Promise<void>((resolve) => {
+        //     auth.onAuthStateChanged(async (user) => {
+        //         userData = user;
+        //         if(userData){
+        //             userLevelsData = await authHandlers.getUserCurrentLevelsData(userData.uid);
+        //             if (userLevelsData && difficulty === "easy"){
+        //                 currentUserLevel = userLevelsData[0];
+        //             }
+        //             else if (userLevelsData && difficulty === "medium"){
+        //                 currentUserLevel = userLevelsData[1];
+        //             }
+        //             else if (userLevelsData && difficulty === "hard"){
+        //                 currentUserLevel = userLevelsData[2];
+        //             }
+        //         }
+        //         resolve();
+        //     });
+        // });
+
         levelData = await authHandlers.getLevels(difficulty);
 		loadLevelWords();
     }
 
     function loadLevelWords() {
-        wordsToFind[0] = levelData[currentUserLevel-1].wordOne;
-        wordsToFind[1] = levelData[currentUserLevel-1].wordTwo;
+        // wordsToFind[0] = levelData[currentUserLevel-1].wordOne;
+        // wordsToFind[1] = levelData[currentUserLevel-1].wordTwo;
+        wordsToFind[0] = levelData[$levelNumber].wordOne;
+        wordsToFind[1] = levelData[$levelNumber].wordTwo;
     }
 
 
@@ -91,7 +94,7 @@
 		// Save level data into database
         isOverlayOpen.set(true);
 		levelOver.set(true);
-        await authHandlers.updateUserLevelsData(userData.uid, difficulty, currentUserLevel + 1);
+        // await authHandlers.updateUserLevelsData(userData.uid, difficulty, currentUserLevel + 1);
 	}
 
     async function playNextLevelClicked() {
@@ -117,9 +120,10 @@
 
 <HeaderBar />
 <div class="levels-page">
-    <GameHeader header="Level: {difficulty.charAt(0).toUpperCase() + difficulty.slice(1)} {currentUserLevel}" arrow={true} backLink="/home"/>
+    <GameHeader header="Level: {difficulty.charAt(0).toUpperCase() + difficulty.slice(1)} {$levelNumber + 1}" arrow={true} backLink="/levels"/>
     {#if levelData}
-    <p class="info-text">You have completed {currentUserLevel-1}/{levelData.length} levels</p>
+    <!-- <p class="info-text">You have completed {currentUserLevel-1}/{levelData.length} levels</p> -->
+    <p class="info-text">You have completed X/{levelData.length} levels</p>
     {/if}
 
 	<div class="game-container">

--- a/wikiclue/src/routes/levels/[level_slug]/+page.svelte
+++ b/wikiclue/src/routes/levels/[level_slug]/+page.svelte
@@ -34,6 +34,7 @@
     async function setupLevel(){
         searchTerm.set('');
         searchResults.set([]);
+
         // await new Promise<void>((resolve) => {
         //     auth.onAuthStateChanged(async (user) => {
         //         userData = user;

--- a/wikiclue/src/routes/levels/[level_slug]/+page.svelte
+++ b/wikiclue/src/routes/levels/[level_slug]/+page.svelte
@@ -60,6 +60,10 @@
             });
         });
 
+        if(levelNumber > maxLevel + 1){
+            goto("/levels");
+        }
+
         levelData = await authHandlers.getLevels(difficulty);
         wordsToFind[0] = levelData[levelNumber-1].wordOne;
         wordsToFind[1] = levelData[levelNumber-1].wordTwo;

--- a/wikiclue/src/routes/levels/[level_slug]/+page.svelte
+++ b/wikiclue/src/routes/levels/[level_slug]/+page.svelte
@@ -12,7 +12,6 @@
     import { getWikiPageContent } from '../../../store/wiki';
     import SearchComponent from '../../../components/searchComponent.svelte';
 
-    const isOverlayOpen = writable(false);
     const levelOver = writable(false);
     const nextLevelAvailable = writable(true);
     let wordsToFind = [''];
@@ -33,12 +32,9 @@
 	});
 
     async function setupLevel(){
-        // Clear search
+        // Reset Page
         searchTerm.set('');
         searchResults.set([]);
-
-        // Reset page
-        isOverlayOpen.set(false);
         levelOver.set(false);
 
         level_slug = $page.params.level_slug;
@@ -92,7 +88,6 @@
                     await authHandlers.updateUserLevelsData(userData.uid, difficulty, levelNumber);
                 }
             }
-            isOverlayOpen.set(true);
             levelOver.set(true);
 		}
 
@@ -111,16 +106,7 @@
         await goto(`/levels/${difficulty}-${levelNumber+1}`);
         setupLevel();
 	}
-
-    function onEnterPressed(event: KeyboardEvent) {
-        if (event.key === "Enter" && $levelOver && !$isOverlayOpen) {
-            playNextLevelClicked();
-            return;
-        }
-    }
 </script>
-
-<svelte:window on:keydown={onEnterPressed} />
 
 <HeaderBar />
 <div class="levels-page">
@@ -139,7 +125,7 @@
 		<SearchComponent gameOver={$levelOver} confirmFunction={levelsConfirmFunction} />
 	</div>
 
-    {#if $isOverlayOpen && $levelOver}
+    {#if $levelOver}
         <Overlay header="Level {levelNumber}" displayX={false}>
 
             <p class="popup-text">Congratulations!</p>

--- a/wikiclue/src/routes/levels/[level_slug]/+page.svelte
+++ b/wikiclue/src/routes/levels/[level_slug]/+page.svelte
@@ -23,10 +23,10 @@
     let userData: any;
     let userLevelsData: any;
 
-   // Extract the level slug from url
-   let level_slug = $page.params.level_slug;
-   let [difficulty, levelStr] = level_slug.split("-");
-   let levelNumber = parseInt(levelStr);
+    // Extract the level slug from url
+    let level_slug = $page.params.level_slug;
+    let [difficulty, levelStr] = level_slug.split("-");
+    let levelNumber = parseInt(levelStr);
 
     onMount(async () => {
         await setupLevel();
@@ -65,14 +65,9 @@
         });
 
         levelData = await authHandlers.getLevels(difficulty);
-		loadLevelWords();
-    }
-
-    function loadLevelWords() {
         wordsToFind[0] = levelData[levelNumber-1].wordOne;
         wordsToFind[1] = levelData[levelNumber-1].wordTwo;
     }
-
 
     async function levelsConfirmFunction() {
         incorrectAnswer = false;
@@ -88,7 +83,6 @@
 
         // Found a correct answer
 		if (pageContent.includes(wordsToFind[0].toLowerCase()) && pageContent.includes(wordsToFind[1].toLowerCase())) {
-
             // Don't go past the available levels
             if(levelNumber >= levelData.length){
                 nextLevelAvailable.set(false);
@@ -98,7 +92,6 @@
                     await authHandlers.updateUserLevelsData(userData.uid, difficulty, levelNumber);
                 }
             }
-
             isOverlayOpen.set(true);
             levelOver.set(true);
 		}
@@ -119,13 +112,9 @@
         setupLevel();
 	}
 
-    function returnToMainMenuClicked() {
-        goto('/home');
-	}
-
     function onEnterPressed(event: KeyboardEvent) {
         if (event.key === "Enter" && $levelOver && !$isOverlayOpen) {
-            playNextLevelClicked()
+            playNextLevelClicked();
             return;
         }
     }
@@ -168,7 +157,7 @@
                 {#if $nextLevelAvailable}
                     <button class="popup-button" on:click={() => {playNextLevelClicked()}}>Play Next Level</button>
                 {/if}
-                <button class="popup-button" on:click={() => {returnToMainMenuClicked()}}>Return to Main Menu</button>
+                <button class="popup-button" on:click={() => {goto("/levels")}}>Return to Level Menu</button>
             </div>
         </Overlay>
     {/if}

--- a/wikiclue/src/routes/levels/[level_slug]/+page.svelte
+++ b/wikiclue/src/routes/levels/[level_slug]/+page.svelte
@@ -4,7 +4,7 @@
     import Overlay from "../../../components/overlay.svelte";
 	import { writable } from "svelte/store";
     import { onMount } from "svelte";
-    import { searchTerm, searchResults, levelNumber } from '../../../store/gameplay';
+    import { searchTerm, searchResults } from '../../../store/gameplay';
     import { goto } from '$app/navigation';
     import { page } from '$app/stores';
     import { authHandlers } from "../../../store/store";
@@ -22,8 +22,10 @@
     let userData: any;
     let userLevelsData: any;
 
-   // Extract the difficulty slug from url
-   const difficulty = $page.params.difficulty;
+   // Extract the level slug from url
+   const level_slug = $page.params.level_slug;
+   const [difficulty, levelStr] = level_slug.split("-");
+   const levelNumber = parseInt(levelStr);
 
     onMount(async () => {
         await setupLevel();
@@ -56,10 +58,8 @@
     }
 
     function loadLevelWords() {
-        // wordsToFind[0] = levelData[currentUserLevel-1].wordOne;
-        // wordsToFind[1] = levelData[currentUserLevel-1].wordTwo;
-        wordsToFind[0] = levelData[$levelNumber].wordOne;
-        wordsToFind[1] = levelData[$levelNumber].wordTwo;
+        wordsToFind[0] = levelData[levelNumber-1].wordOne;
+        wordsToFind[1] = levelData[levelNumber-1].wordTwo;
     }
 
 
@@ -120,11 +120,7 @@
 
 <HeaderBar />
 <div class="levels-page">
-    <GameHeader header="Level: {difficulty.charAt(0).toUpperCase() + difficulty.slice(1)} {$levelNumber + 1}" arrow={true} backLink="/levels"/>
-    {#if levelData}
-    <!-- <p class="info-text">You have completed {currentUserLevel-1}/{levelData.length} levels</p> -->
-    <p class="info-text">You have completed X/{levelData.length} levels</p>
-    {/if}
+    <GameHeader header="Level: {difficulty.charAt(0).toUpperCase() + difficulty.slice(1)} {levelNumber}" arrow={true} backLink="/levels"/>
 
 	<div class="game-container">
         <p class="game-description">Find A Wiki page with</p>

--- a/wikiclue/src/store/gameplay.ts
+++ b/wikiclue/src/store/gameplay.ts
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store';
 
+// Search Variables
 const searchTerm = writable('');
 const searchResults = writable([]);
 
@@ -7,7 +8,8 @@ const searchResults = writable([]);
 const guestTimeAllowed = writable(60);
 const guestSkipsRemaining = writable(3);
 
-// Levels Variables if needed
+// Levels Variables
+const levelNumber = writable(0);
 
 // The Daily Variables if needed
 
@@ -37,5 +39,5 @@ const rush = {
 	skipsRemaining: rushSkipsRemaining
 };
 
-export { guestPlay, rush, searchTerm, searchResults };
+export { guestPlay, rush, searchTerm, searchResults, levelNumber };
 export type {theDaily}

--- a/wikiclue/src/store/gameplay.ts
+++ b/wikiclue/src/store/gameplay.ts
@@ -8,8 +8,7 @@ const searchResults = writable([]);
 const guestTimeAllowed = writable(60);
 const guestSkipsRemaining = writable(3);
 
-// Levels Variables
-const levelNumber = writable(0);
+// Levels Variables if needed
 
 // The Daily Variables if needed
 
@@ -39,5 +38,5 @@ const rush = {
 	skipsRemaining: rushSkipsRemaining
 };
 
-export { guestPlay, rush, searchTerm, searchResults, levelNumber };
+export { guestPlay, rush, searchTerm, searchResults };
 export type {theDaily}

--- a/wikiclue/src/store/store.ts
+++ b/wikiclue/src/store/store.ts
@@ -56,9 +56,9 @@ export const authHandlers = {
 					lastplay: Timestamp.fromDate(new Date(new Date().getTime() - 86400000)),
 					currentGuesses: 6
 				},
-				currenteasylevel: 1,
-				currentmediumlevel: 1,
-				currenthardlevel: 1,
+				currenteasylevel: 0,
+				currentmediumlevel: 0,
+				currenthardlevel: 0,
 				totallevels: 0,
 				maxstreak: 0,
 				rush: 0

--- a/wikiclue/src/styles/levelsPageStyles.css
+++ b/wikiclue/src/styles/levelsPageStyles.css
@@ -5,11 +5,6 @@
 	margin-top: 15vh;
 }
 
-.info-text {
-	font-size: 1.2rem;
-	margin: 3vh 0;
-}
-
 .game-container {
 	background-color: var(--card-background);
 	margin-top: 20px;
@@ -77,7 +72,7 @@
 	width: 240px;
 	max-width: 85%;
 	bottom: 20px;
-	gap: 10px;
+	gap: 30px;
 }
 
 .popup-button {
@@ -91,10 +86,4 @@
 
 .popup-button:hover {
 	background-color: var(--default-button-color-lighter);
-}
-
-hr {
-	width: 100%;
-	border: 1px solid var(--input-border-color);
-	margin-top: 1rem;
 }

--- a/wikiclue/src/styles/levelsPageStyles.css
+++ b/wikiclue/src/styles/levelsPageStyles.css
@@ -12,11 +12,11 @@
 
 .game-container {
 	background-color: var(--card-background);
+	margin-top: 20px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	text-align: center;
-	margin: auto;
 	width: 700px;
 	max-height: 275px;
 	max-width: 95vw;

--- a/wikiclue/src/styles/selectLevelPageStyles.css
+++ b/wikiclue/src/styles/selectLevelPageStyles.css
@@ -17,25 +17,13 @@
 	cursor:pointer;
 }
 
-/* Option header */
-
-.options-container {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: center;
-	align-items: center;
-	width: 70vw;
-	margin: 20px;
-	/* margin-bottom: 10px; */
-	min-width: 350px;
-}
-
 /* Update Levels Section */
 
 .change-difficulty {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+	margin: 20px;
 }
 
 h3 {
@@ -63,9 +51,9 @@ h3 {
 	max-width: 125px;
 	max-height: 125px;
 	margin: 1%;
+	border: none;
 	box-sizing: border-box;
 	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
-	aspect-ratio: 1;
 	cursor: pointer;
 	background: var(--card-background);
 }

--- a/wikiclue/src/styles/selectLevelPageStyles.css
+++ b/wikiclue/src/styles/selectLevelPageStyles.css
@@ -61,3 +61,7 @@ h3 {
 .level:hover {
 	background-color: var(--card-background-darker);
 }
+
+.level:disabled {
+	background-color: var(--card-background-locked);
+}

--- a/wikiclue/src/styles/selectLevelPageStyles.css
+++ b/wikiclue/src/styles/selectLevelPageStyles.css
@@ -1,0 +1,75 @@
+.select-level-page {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 15vh;
+}
+
+.dropdown {
+	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
+	width: 150px;
+	height: 30px;
+	background: var(--card-background);
+	border: 1px solid var(--search-border);
+	border: 1px;
+	font-size: 1.25rem;
+	font-family: inherit;
+	cursor:pointer;
+}
+
+/* Option header */
+
+.options-container {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	align-items: center;
+	width: 70vw;
+	margin: 20px;
+	/* margin-bottom: 10px; */
+	min-width: 350px;
+}
+
+/* Update Levels Section */
+
+.change-difficulty {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}
+
+h3 {
+	margin-right: 10px;
+}
+
+.level-options-container {
+	margin: auto;
+	width: 80vw;
+	min-width: 350px;
+	display: flex;
+	flex-wrap: wrap;
+	flex-basis: calc(100% - 150px);
+	align-content: start;
+	justify-content: center;
+	margin-bottom: 5vh;
+}
+
+.level {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 20vw;
+	height: 20vw;
+	max-width: 125px;
+	max-height: 125px;
+	margin: 1%;
+	box-sizing: border-box;
+	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
+	aspect-ratio: 1;
+	cursor: pointer;
+	background: var(--card-background);
+}
+
+.level:hover {
+	background-color: var(--card-background-darker);
+}


### PR DESCRIPTION
A lot going on here, the best way to test is probably just pull down and play

Heres a summary:

- /levels route now shows a menu of levels to choose from
- it has a dropdown for difficulty
- levels past the max are visibly locked and unclickable
- old levels are playable
- only the max level will update the database
- the page works in terms of a re-route to the correct slug, then loading all the content
- this makes it work from clicking a level from /levels or from clicking play next level
- the last level does not have a button for play next level, only return to main menu